### PR TITLE
Session numbers for linking processing session fix

### DIFF
--- a/Data Analysis Management Module/Helper Functions/GUI Helper Functions/getSessionNumbersFromListBox.m
+++ b/Data Analysis Management Module/Helper Functions/GUI Helper Functions/getSessionNumbersFromListBox.m
@@ -1,0 +1,18 @@
+function linkedSessionNumbers = getSessionNumbersFromListBox(sessionListboxHandle, sessionChoices)
+% getSessionNumbersFromListBox
+
+choices = get(sessionListboxHandle, 'Value');
+
+numChoices = length(choices);
+
+linkedSessionNumbers = zeros(numChoices, 1);
+
+for i=1:numChoices
+    session = sessionChoices{choices(i)};
+    
+    linkedSessionNumbers(i) = session.sessionNumber;
+end
+
+
+end
+

--- a/Data Analysis Management Module/Metadata GUIs/LegacyRegistrationSessionMetadataEntry.m
+++ b/Data Analysis Management Module/Metadata GUIs/LegacyRegistrationSessionMetadataEntry.m
@@ -62,7 +62,7 @@ handles.output = hObject;
 
 handles.importPath = varargin{1}; %Param is importPath
 handles.userName = varargin{2}; %Param is userName
-sessionChoices = varargin{3}; %Param is sessionChoices
+handles.sessionChoices = varargin{3}; %Param is sessionChoices
 
 isEdit = varargin{4};
 
@@ -142,7 +142,7 @@ setPopUpMenu(handles.registrationTypeList, defaultChoiceString, choices, selecte
 
 listBoxHandle = handles.sessionListbox;
 
-setSessionListBox(listBoxHandle, sessionChoices, handles.linkedSessionNumbers);
+setSessionListBox(listBoxHandle, handles.sessionChoices, handles.linkedSessionNumbers);
 
 
 % ** SET REJECTED INPUTS **
@@ -171,7 +171,8 @@ function varargout = LegacyRegistrationSessionMetadataEntry_OutputFcn(hObject, e
 %OUTPUT: [cancel, sessionDate, sessionDoneBy, notes, registrationType, registrationParams, rejected, rejectedReason, rejectedBy, sessionChoices]
 %*******************************************************************************************************************************
 
-handles.linkedSessionNumbers = get(handles.sessionListbox, 'Value');
+handles.linkedSessionNumbers = getSessionNumbersFromListBox(handles.sessionListbox, handles.sessionChoices);
+get(handles.sessionListbox, 'Value');
 guidata(hObject, handles);
 
 % Get default command line output from handles structure

--- a/Data Analysis Management Module/Metadata GUIs/LegacySubsectionSelectionSessionMetadataEntry.m
+++ b/Data Analysis Management Module/Metadata GUIs/LegacySubsectionSelectionSessionMetadataEntry.m
@@ -62,7 +62,7 @@ handles.output = hObject;
 
 handles.importPath = varargin{1}; %Param is importPath
 handles.userName = varargin{2}; %Param is userName
-sessionChoices = varargin{3}; %Param is sessionChoices
+handles.sessionChoices = varargin{3}; %Param is sessionChoices
 
 isEdit = varargin{4};
 
@@ -162,7 +162,7 @@ setPopUpMenu(handles.croppingTypeMenu, defaultChoiceString, choices, selectedCho
 
 listBoxHandle = handles.sessionListBox;
 
-setSessionListBox(listBoxHandle, sessionChoices, handles.linkedSessionNumbers);
+setSessionListBox(listBoxHandle, handles.sessionChoices, handles.linkedSessionNumbers);
 
 
 % ** SET REJECTED INPUTS **
@@ -191,7 +191,7 @@ function varargout = LegacySubsectionSelectionSessionMetadataEntry_OutputFcn(hOb
 %OUTPUT:  [cancel, sessionDate, sessionDoneBy, notes, croppingType, coords, rejected, rejectedReason, rejectedBy, sessionChoices]
 %********************************************************************************************************************************
 
-handles.sessionChoices = get(handles.sessionListBox, 'Value');
+handles.sessionChoices = getSessionNumbersFromListBox(handles.sessionListBox, handles.sessionChoices);
 guidata(hObject, handles);
 
 % Get default command line output from handles structure


### PR DESCRIPTION
- the selection values from the listbox were being recorded instead of
  the session numbers
- luckily, this won't create any errors since session numbers can't be
  changed and they auto increment, but the proper fix is in now
